### PR TITLE
fix: add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,5 +114,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "main": "lib/index.js"
 }


### PR DESCRIPTION
### What does this PR do?

Adds the `main` entry to the package.json in order to improve the performance of module resolution in oclif/core

### What issues does this PR fix or reference?
[skip-validate-pr]