### PR TITLE
Update "generate" topic desc to match the one in plugin-functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     ],
     "topics": {
       "generate": {
-        "description": "Commands to generate things from templates."
+        "description": "Commands to generate a project, create a function, and more."
       }
     }
   },


### PR DESCRIPTION
### What does this PR do?

We currently require that all plugins provide a top-level topic description in package.json if they create sub-topics.  But then we have multiple descriptions for the same top-level topic, and it's currently indeterminate which "wins".  For now I'll just make the descriptions the same.  

### What issues does this PR fix or reference?

@W-11195350@
